### PR TITLE
removed sub(2) from dokx._getDokxDir

### DIFF
--- a/luasrc/utils.lua
+++ b/luasrc/utils.lua
@@ -279,7 +279,7 @@ function dokx._filterFiles(files, pattern, invert)
 end
 
 function dokx._getDokxDir()
-    return path.dirname(debug.getinfo(1, 'S').source:gsub('^[@=]', '')):sub(2)
+    return path.dirname(debug.getinfo(1, 'S').source:gsub('^[@=]', ''))
 end
 
 function dokx._getTemplate(templateFile)


### PR DESCRIPTION
Removed the sub(2) from dokx._getDokxDir as this was stripping the leading / from the path. For example, `debug.getinfor(1, 'S').source` is returning `@/Users/aly/workspace/torch/install/share/lua/5.1/dokx/` the gsub correctly removes the `@` but the `sub(2)` also removes the / so when `dokx._getTemplate()` is run it points to a path that doesn't exist (as the leading / was stripped)