### PR TITLE
Remove redundant _exitWithTester function

### DIFF
--- a/luasrc/testUtils.lua
+++ b/luasrc/testUtils.lua
@@ -41,27 +41,6 @@ end
 
 --[[
 
-Stop execution, with exit code:
-
-* 0 if the given torch.Tester had no errors
-* 1 if there were errors
-
-Parameters:
-* `tester` - torch.Tester, after 'tester:run()' has been called.
-
-DOES NOT RETURN!
-
-]]
-function dokx._exitWithTester(tester)
-    local code = 0
-    if not tester.errors or #tester.errors ~= 0 then
-        code = 1
-    end
-    os.exit(code)
-end
-
---[[
-
 Check that two strings are equal, and if they're not, print a diff.
 
 Parameters:

--- a/tests/testCombineTOC.lua
+++ b/tests/testCombineTOC.lua
@@ -25,6 +25,4 @@ function myTests.testCombineTOC()
     path.rmdir(tmpDir)
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testExtract.lua
+++ b/tests/testExtract.lua
@@ -166,6 +166,4 @@ require 'module'
     tester:asserteq(fileString, false, "no file string expected")
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testExtractMarkdown.lua
+++ b/tests/testExtractMarkdown.lua
@@ -22,6 +22,4 @@ function myTests.testExtractMarkdown()
     path.rmdir(tmpDir)
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testExtractTOCMarkdown.lua
+++ b/tests/testExtractTOCMarkdown.lua
@@ -131,6 +131,4 @@ function myTests:testExtractTOCMarkdown()
     dokx._assertEqualWithDiff(tester, output, expected, "-u")
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testParsing.lua
+++ b/tests/testParsing.lua
@@ -278,6 +278,4 @@ bar =
   tester:assertne(parser(testInput), nil, "interposing comment should parse")
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testREPL.lua
+++ b/tests/testREPL.lua
@@ -53,6 +53,4 @@ function myTests:testREPL()
     end
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()

--- a/tests/testScripts.lua
+++ b/tests/testScripts.lua
@@ -100,6 +100,4 @@ function myTests:test_update_from_git()
 
 end
 
-tester:add(myTests)
-tester:run()
-dokx._exitWithTester(tester)
+tester:add(myTests):run()


### PR DESCRIPTION
It seems that this facility serves no purpose; `tester:run()` already exits in the right way.